### PR TITLE
Move nonce retry from jws to http (#367)

### DIFF
--- a/acme/http.go
+++ b/acme/http.go
@@ -97,10 +97,41 @@ func postJSON(j *jws, uri string, reqBody, respBody interface{}) (http.Header, e
 	if err != nil {
 		return nil, fmt.Errorf("Failed to post JWS message. -> %v", err)
 	}
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		return resp.Header, handleHTTPError(resp)
+
+		err := handleHTTPError(resp)
+
+		switch err.(type) {
+
+		case NonceError:
+
+			// Retry once if the nonce was invalidated
+
+			retryResp, err := j.post(uri, jsonBytes)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to post JWS message. -> %v", err)
+			}
+
+			defer retryResp.Body.Close()
+
+			if retryResp.StatusCode >= http.StatusBadRequest {
+				return retryResp.Header, handleHTTPError(retryResp)
+			}
+
+			if respBody == nil {
+				return retryResp.Header, nil
+			}
+
+			return retryResp.Header, json.NewDecoder(retryResp.Body).Decode(respBody)
+
+		default:
+			return resp.Header, err
+
+		}
+
 	}
 
 	if respBody == nil {

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -44,24 +44,10 @@ func (j *jws) post(url string, content []byte) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to HTTP POST to %s -> %s", url, err.Error())
 	}
-	
-	// Even in case of an error, the response should still contain a nonce.
+
 	nonce, nonceErr := getNonceFromResponse(resp)
 	if nonceErr == nil {
 		j.nonces.Push(nonce)
-	}
-
-	if err != nil {
-		switch err.(type) {
-		case NonceError:
-			// In case of a nonce error - retry once
-			resp, err = httpPost(url, "application/jose+json", bytes.NewBuffer([]byte(signedContent.FullSerialize())))
-			if err != nil {
-				return nil, fmt.Errorf("Failed to HTTP POST to %s -> %s", url, err.Error())
-			}
-		default:
-			return nil, fmt.Errorf("Failed to HTTP POST to %s -> %s", url, err.Error())
-		}
 	}
 
 	return resp, nil


### PR DESCRIPTION
* Move nonce retry from jws to http

The error raised by an "invalid nonce" response never appeared
inside jws.go, but instead it was handled at http.go, so it makes
sense to move the retry logic to that file. The previous code from
jws.go had no effect and did not solve issues related to invalid
nonces.

* Rename retry response variable name for clarity